### PR TITLE
[auto] fix: replace LLM search with Yandex Cloud Search API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,6 @@ BOT_TOKEN=your_telegram_bot_token_here
 # Example: video.ragpt.ru
 AITOVIDEO_DOMAIN=video.ragpt.ru
 
-OPENROUTER_API_KEY=   # OpenRouter API key (for Perplexity Sonar alternative video search)
+OPENROUTER_API_KEY=   # OpenRouter API key (legacy, no longer used)
+YANDEX_SEARCH_API_KEY=   # Yandex Cloud Search API key (for VK/Rutube alternative search)
+YANDEX_FOLDER_ID=        # Yandex Cloud folder ID

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,11 +48,13 @@ jobs:
           script: |
             docker service update \
               --image rast53/aitovideo-backend:${{ github.sha }} \
-              --env-add OPENROUTER_API_KEY=$OPENROUTER_API_KEY \
+              --env-add YANDEX_SEARCH_API_KEY=$YANDEX_SEARCH_API_KEY \
+              --env-add YANDEX_FOLDER_ID=$YANDEX_FOLDER_ID \
               aitovideo_backend
             docker service update --image rast53/aitovideo-miniapp:${{ github.sha }} aitovideo_miniapp
             docker service update \
               --image rast53/aitovideo-backend:${{ github.sha }} \
               aitovideo_bot
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          YANDEX_SEARCH_API_KEY: ${{ secrets.YANDEX_SEARCH_API_KEY }}
+          YANDEX_FOLDER_ID: ${{ secrets.YANDEX_FOLDER_ID }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - VK_SERVICE_TOKEN=${VK_SERVICE_TOKEN:-}
       - YTDLP_PROXY=${YTDLP_PROXY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - YANDEX_SEARCH_API_KEY=${YANDEX_SEARCH_API_KEY:-}
+      - YANDEX_FOLDER_ID=${YANDEX_FOLDER_ID:-}
     volumes:
       - backend-data:/app/data
     networks:


### PR DESCRIPTION
Replaces Perplexity Sonar (hallucinated URLs) with Yandex Cloud Search API.

## Why Yandex
- Best index of Russian-language VK and Rutube content
- Official API, no scraping, no captcha
- Free tier: 1000 req/day

## Changes
- `ai-search.ts` — async Yandex Search API, extracts real VK/Rutube URLs from HTML results
- `docker-compose.yml` — added `YANDEX_SEARCH_API_KEY` and `YANDEX_FOLDER_ID`
- `.env.example` — documented new vars
- `deploy.yml` — CI injects keys from GitHub Secrets on deploy

Closes #29