### PR TITLE
feat: add branded platform icons (SVG)

### DIFF
--- a/miniapp/src/components/VideoCard.css
+++ b/miniapp/src/components/VideoCard.css
@@ -35,8 +35,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 32px;
   background: var(--tg-theme-bg-color);
+}
+
+.video-thumbnail-placeholder .platform-icon {
+  width: 64px;
+  height: 64px;
 }
 
 .video-duration {
@@ -85,6 +89,11 @@
   color: #fff;
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
+}
+
+.video-platform-badge .platform-icon {
+  width: 16px;
+  height: 16px;
 }
 
 /* ── Info section ──────────────────────────────────────────────────────── */
@@ -158,9 +167,20 @@
   transform: scale(0.95);
 }
 
+.platform-icon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  flex-shrink: 0;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .alt-chip-icon {
   font-size: 10px;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
 }
 
 .alt-chip-name {

--- a/miniapp/src/components/VideoCard.tsx
+++ b/miniapp/src/components/VideoCard.tsx
@@ -1,5 +1,6 @@
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import type { Video, VideoPlatform } from '../types/api';
+import { YouTubeIcon, VKIcon, RutubeIcon } from './icons/index.js';
 import './VideoCard.css';
 
 const API_URL: string = import.meta.env.VITE_API_URL ?? '';
@@ -25,16 +26,10 @@ const platformNames: Record<VideoPlatform, string> = {
   vk: 'VK Video'
 };
 
-const platformIcons: Record<VideoPlatform, string> = {
-  youtube: '🔴',
-  rutube: '▶️',
-  vk: '🔵'
-};
-
-const platformEmojis: Record<VideoPlatform, string> = {
-  youtube: '📹',
-  rutube: '🎥',
-  vk: '📱'
+const platformIconComponents: Record<VideoPlatform, (size: number) => ReactNode> = {
+  youtube: (size) => <YouTubeIcon size={size} className="platform-icon" />,
+  rutube: (size) => <RutubeIcon size={size} className="platform-icon" />,
+  vk: (size) => <VKIcon size={size} className="platform-icon" />,
 };
 
 function formatDuration(seconds: number | null): string {
@@ -91,13 +86,16 @@ export function VideoCard({ video, alternatives = [], onClick, onDelete, onMarkW
           />
         ) : null}
         <div className="video-thumbnail-placeholder" style={{ display: thumbnailSrc ? 'none' : 'flex' }}>
-          {platformEmojis[video.platform] ?? '📹'}
+          {platformIconComponents[video.platform]?.(64)}
         </div>
         {video.duration !== null && video.duration > 0 && (
           <span className="video-duration">{formatDuration(video.duration)}</span>
         )}
         {isWatched && <span className="video-watched-badge">✓</span>}
-        <span className="video-platform-badge">{platformNames[video.platform]}</span>
+        <span className="video-platform-badge">
+          {platformIconComponents[video.platform]?.(16)}
+          {platformNames[video.platform]}
+        </span>
       </div>
 
       <div className="video-info">
@@ -118,7 +116,7 @@ export function VideoCard({ video, alternatives = [], onClick, onDelete, onMarkW
                     onClick={(e) => handleAltClick(e, alt)}
                     title={alt.title}
                   >
-                    <span className="alt-chip-icon">{platformIcons[alt.platform]}</span>
+                    <span className="alt-chip-icon">{platformIconComponents[alt.platform]?.(20)}</span>
                     <span className="alt-chip-name">{platformNames[alt.platform]}</span>
                     {alt.channel_name && alt.channel_name !== 'Unknown' && (
                       <span className="alt-chip-channel">· {alt.channel_name}</span>

--- a/miniapp/src/components/icons/RutubeIcon.tsx
+++ b/miniapp/src/components/icons/RutubeIcon.tsx
@@ -1,0 +1,51 @@
+import { useId } from 'react';
+
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+export function RutubeIcon({ size = 20, className }: IconProps) {
+  const uid = useId();
+  const bgId = `rt-bg-${uid}`;
+  const waveId = `rt-wave-${uid}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <defs>
+        <linearGradient id={bgId} x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="#2ECC71" />
+          <stop offset="100%" stopColor="#1A9B52" />
+        </linearGradient>
+        <linearGradient id={waveId} x1="0" y1="256" x2="512" y2="256" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="white" stopOpacity="0.08" />
+          <stop offset="50%" stopColor="white" stopOpacity="0.15" />
+          <stop offset="100%" stopColor="white" stopOpacity="0.05" />
+        </linearGradient>
+      </defs>
+      <rect x="16" y="16" width="480" height="480" rx="96" fill={`url(#${bgId})`} />
+      <path
+        d="M16 280 Q128 240 256 270 Q384 300 496 260 L496 496 Q496 496 480 496 L32 496 Q16 496 16 480Z"
+        fill={`url(#${waveId})`}
+      />
+      <path d="M208 176 L352 256 L208 336Z" fill="white" fillOpacity="0.95" />
+      <path
+        d="M100 380 Q180 350 256 370 Q332 390 412 360"
+        stroke="white"
+        strokeWidth="6"
+        strokeOpacity="0.3"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+export default RutubeIcon;

--- a/miniapp/src/components/icons/VKIcon.tsx
+++ b/miniapp/src/components/icons/VKIcon.tsx
@@ -1,0 +1,46 @@
+import { useId } from 'react';
+
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+export function VKIcon({ size = 20, className }: IconProps) {
+  const uid = useId();
+  const bgId = `vk-bg-${uid}`;
+  const shadowId = `vk-shadow-${uid}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <defs>
+        <linearGradient id={bgId} x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="#5B8DEF" />
+          <stop offset="100%" stopColor="#0054AF" />
+        </linearGradient>
+        <linearGradient id={shadowId} x1="256" y1="400" x2="256" y2="512" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="black" stopOpacity="0" />
+          <stop offset="100%" stopColor="black" stopOpacity="0.12" />
+        </linearGradient>
+      </defs>
+      <circle cx="256" cy="256" r="240" fill={`url(#${bgId})`} />
+      <circle cx="256" cy="256" r="240" fill={`url(#${shadowId})`} />
+      <path
+        d="M148 192 Q148 192 192 320 Q210 368 240 320 L256 288 L272 320 Q302 368 320 320 Q364 192 364 192"
+        stroke="white"
+        strokeWidth="36"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+export default VKIcon;

--- a/miniapp/src/components/icons/YouTubeIcon.tsx
+++ b/miniapp/src/components/icons/YouTubeIcon.tsx
@@ -1,0 +1,39 @@
+import { useId } from 'react';
+
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+export function YouTubeIcon({ size = 20, className }: IconProps) {
+  const uid = useId();
+  const bgId = `yt-bg-${uid}`;
+  const glossId = `yt-gloss-${uid}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <defs>
+        <linearGradient id={bgId} x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="#FF1A1A" />
+          <stop offset="100%" stopColor="#CC0000" />
+        </linearGradient>
+        <linearGradient id={glossId} x1="256" y1="0" x2="256" y2="256" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stopColor="white" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="white" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <rect x="16" y="16" width="480" height="480" rx="96" fill={`url(#${bgId})`} />
+      <rect x="16" y="16" width="480" height="240" rx="96" fill={`url(#${glossId})`} />
+      <path d="M208 176 L352 256 L208 336Z" fill="white" />
+    </svg>
+  );
+}
+
+export default YouTubeIcon;

--- a/miniapp/src/components/icons/index.ts
+++ b/miniapp/src/components/icons/index.ts
@@ -1,0 +1,3 @@
+export { YouTubeIcon } from './YouTubeIcon.js';
+export { VKIcon } from './VKIcon.js';
+export { RutubeIcon } from './RutubeIcon.js';

--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/**
+ * Generate platform icons via Gemini API (gemini-3.1-flash-image).
+ * Requires GEMINI_API_KEY env var.
+ * Falls back to a message if the API is unavailable.
+ *
+ * Usage: GEMINI_API_KEY=your-key node scripts/generate-icons.mjs
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_DIR = join(__dirname, '..', 'miniapp', 'src', 'assets', 'icons');
+
+const API_KEY = process.env.GEMINI_API_KEY;
+
+const PROMPTS = {
+  youtube: 'Minimalist app icon for a video platform. Red and white color scheme. A bold play triangle inside a softly rounded rectangle with a subtle gloss effect. Modern flat design with slight depth. Clean, no text, no labels. Style: contemporary tech product icon, reminiscent of streaming apps but visually distinct and original. 512x512px',
+  vk: 'Minimalist app icon for a social video platform. Deep blue and white color scheme. Abstract letter V with smooth curves inside a circle with soft gradient background. Modern flat design with subtle shadow. Clean, no text, no labels. Style: contemporary social app icon, inspired by Eastern European design sensibility, original and unique. 512x512px',
+  rutube: 'Minimalist app icon for a video hosting platform. Green and white color scheme. Abstract play button with a subtle wave or stream motif inside a rounded square. Modern flat design with gradient. Clean, no text, no labels. Style: contemporary streaming platform icon, fresh and distinct, Russian design aesthetic. 512x512px',
+};
+
+async function generateIcon(name, prompt) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent?key=${API_KEY}`;
+
+  const body = {
+    contents: [{
+      parts: [{ text: prompt }],
+    }],
+    generationConfig: {
+      responseModalities: ['IMAGE', 'TEXT'],
+      imageMimeType: 'image/png',
+    },
+  };
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`API error ${res.status}: ${text}`);
+  }
+
+  const data = await res.json();
+
+  const parts = data.candidates?.[0]?.content?.parts ?? [];
+  const imagePart = parts.find(p => p.inlineData?.mimeType?.startsWith('image/'));
+
+  if (!imagePart) {
+    throw new Error(`No image returned for ${name}. Response: ${JSON.stringify(data).slice(0, 500)}`);
+  }
+
+  return Buffer.from(imagePart.inlineData.data, 'base64');
+}
+
+async function main() {
+  if (!API_KEY) {
+    console.error('ERROR: GEMINI_API_KEY environment variable is not set.');
+    console.error('FIX: export GEMINI_API_KEY=your-key && node scripts/generate-icons.mjs');
+    console.error('');
+    console.error('SVG fallback icons are already available in miniapp/src/components/icons/');
+    process.exit(1);
+  }
+
+  if (!existsSync(OUTPUT_DIR)) {
+    mkdirSync(OUTPUT_DIR, { recursive: true });
+    console.log(`Created directory: ${OUTPUT_DIR}`);
+  }
+
+  for (const [name, prompt] of Object.entries(PROMPTS)) {
+    const filename = `${name}.png`;
+    const filepath = join(OUTPUT_DIR, filename);
+
+    console.log(`Generating ${filename}...`);
+    try {
+      const imageBuffer = await generateIcon(name, prompt);
+      writeFileSync(filepath, imageBuffer);
+      console.log(`  Saved: ${filepath} (${imageBuffer.length} bytes)`);
+    } catch (err) {
+      console.error(`  FAILED: ${err.message}`);
+    }
+  }
+
+  console.log('\nDone. Icons saved to:', OUTPUT_DIR);
+}
+
+main();


### PR DESCRIPTION
## Что сделано

Заменил emoji-заглушки на полноценные SVG-иконки платформ.

### Иконки

- **YouTube** — красный скруглённый прямоугольник, глянцевый градиент, белый play-треугольник
- **VK Video** — синий круг с градиентом (светло→тёмно синий), абстрактная буква V
- **Rutube** — зелёный скруглённый прямоугольник, волновой элемент снизу, белый play + тонкая линия-волна

### Технические детали

- Каждая иконка — React SVG-компонент с `useId()` для уникальных gradient ID
- Принимает `size` (default 20) и `className` props
- Используется в: platform badge, thumbnail placeholder, alt-chips
- Скрипт `scripts/generate-icons.mjs` для будущей генерации PNG через Gemini API

Closes #