### PR TITLE
[auto] feat: landscape 4-column grid (#34)

### DIFF
--- a/miniapp/src/components/VideoList.css
+++ b/miniapp/src/components/VideoList.css
@@ -5,6 +5,27 @@
   padding: 12px 16px 16px;
 }
 
+@media (orientation: landscape) {
+  .video-list {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+  }
+
+  .video-list .video-title {
+    font-size: 13px;
+  }
+
+  .video-list .video-channel {
+    font-size: 11px;
+  }
+
+  .video-list .video-action-btn {
+    font-size: 12px;
+    padding: 8px 6px;
+  }
+}
+
 .video-list-empty {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
В ландшафтной ориентации видео теперь отображаются в 4 колонки.

## Changes
- `VideoList.css`: добавлен `@media (orientation: landscape)` с `grid-template-columns: repeat(4, 1fr)`
- Шрифты незначительно уменьшены для компактных карточек (title: 14→13px, channel: 12→11px, actions: 13→12px)
- Portrait-режим без изменений

## Acceptance Criteria
- [x] Portrait: 1 колонка (без изменений)
- [x] Landscape: 4 колонки
- [x] Карточки не обрезают текст (line-clamp работает)
- [x] Только CSS — никаких изменений логики

Closes #34