### PR TITLE
[auto] feat: tabs — Видео / Просмотрено / Подписки (#37)

### DIFF
--- a/miniapp/src/App.tsx
+++ b/miniapp/src/App.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api } from './api';
 import { Player } from './components/Player';
+import { TabBar } from './components/TabBar';
+import type { Tab } from './components/TabBar';
 import { VideoList } from './components/VideoList';
 import type { AppUser, Video } from './types/api';
 import './App.css';
@@ -15,6 +17,13 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [selectedVideo, setSelectedVideo] = useState<Video | null>(null);
   const [user, setUser] = useState<AppUser | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('videos');
+
+  const visibleVideos = useMemo(() => {
+    if (activeTab === 'videos') return videos.filter((v) => !v.is_watched);
+    if (activeTab === 'watched') return videos.filter((v) => v.is_watched);
+    return [];
+  }, [videos, activeTab]);
 
   // Initialize Telegram WebApp
   useEffect(() => {
@@ -101,13 +110,16 @@ function App() {
         {user && <span className="user-name">{user.firstName || user.username}</span>}
       </header>
 
+      <TabBar activeTab={activeTab} onChange={setActiveTab} />
+
       <main className="app-content">
         <VideoList
-          videos={videos}
+          videos={visibleVideos}
           loading={loading}
           onVideoClick={handleVideoClick}
           onDelete={handleDelete}
           onMarkWatched={handleMarkWatched}
+          activeTab={activeTab}
         />
       </main>
 

--- a/miniapp/src/components/TabBar.css
+++ b/miniapp/src/components/TabBar.css
@@ -1,0 +1,31 @@
+.tab-bar {
+  position: sticky;
+  top: 57px;
+  z-index: 90;
+  display: flex;
+  background: var(--tg-theme-bg-color);
+  border-bottom: 1px solid var(--tg-theme-secondary-bg-color);
+}
+
+.tab-bar__item {
+  flex: 1;
+  padding: 12px 0;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--tg-theme-hint-color);
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab-bar__item:active {
+  opacity: 0.8;
+}
+
+.tab-bar__item--active {
+  color: var(--tg-theme-button-color);
+  border-bottom-color: var(--tg-theme-button-color);
+}

--- a/miniapp/src/components/TabBar.tsx
+++ b/miniapp/src/components/TabBar.tsx
@@ -1,0 +1,30 @@
+import './TabBar.css';
+
+export type Tab = 'videos' | 'watched' | 'subscriptions';
+
+interface TabBarProps {
+  activeTab: Tab;
+  onChange: (tab: Tab) => void;
+}
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'videos', label: 'Видео' },
+  { key: 'watched', label: 'Просмотрено' },
+  { key: 'subscriptions', label: 'Подписки' },
+];
+
+export function TabBar({ activeTab, onChange }: TabBarProps) {
+  return (
+    <nav className="tab-bar">
+      {TABS.map(({ key, label }) => (
+        <button
+          key={key}
+          className={`tab-bar__item${key === activeTab ? ' tab-bar__item--active' : ''}`}
+          onClick={() => onChange(key)}
+        >
+          {label}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/miniapp/src/components/VideoList.tsx
+++ b/miniapp/src/components/VideoList.tsx
@@ -1,4 +1,5 @@
 import { VideoCard } from './VideoCard';
+import type { Tab } from './TabBar';
 import type { Video } from '../types/api';
 import './VideoList.css';
 
@@ -8,6 +9,7 @@ interface VideoListProps {
   onDelete?: (id: number) => void;
   onMarkWatched?: (id: number, isWatched: boolean) => void;
   loading: boolean;
+  activeTab?: Tab;
 }
 
 function SkeletonCard() {
@@ -26,12 +28,19 @@ function SkeletonCard() {
   );
 }
 
+const EMPTY_STATE: Record<Tab, { icon: string; title: string; message: string }> = {
+  videos: { icon: '📺', title: 'Нет видео', message: 'Отправь ссылку боту, и она появится здесь' },
+  watched: { icon: '✅', title: 'Нет просмотренных', message: 'Отмечай видео как просмотренные, и они появятся здесь' },
+  subscriptions: { icon: '🔔', title: 'Подписки появятся здесь', message: 'Скоро тут можно будет подписываться на каналы' },
+};
+
 export function VideoList({
   videos,
   onVideoClick,
   onDelete,
   onMarkWatched,
-  loading
+  loading,
+  activeTab = 'videos'
 }: VideoListProps) {
   if (loading) {
     return (
@@ -45,11 +54,12 @@ export function VideoList({
   }
 
   if (!videos || videos.length === 0) {
+    const empty = EMPTY_STATE[activeTab];
     return (
       <div className="video-list-empty">
-        <div className="empty-icon">📺</div>
-        <h3>Нет видео</h3>
-        <p>Отправь ссылку боту, и она появится здесь</p>
+        <div className="empty-icon">{empty.icon}</div>
+        <h3>{empty.title}</h3>
+        <p>{empty.message}</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Добавлена навигация по вкладкам над списком видео.

## Changes
- `TabBar.tsx` — новый компонент, тип `Tab = 'videos' | 'watched' | 'subscriptions'`
- `TabBar.css` — стили по BRAND.md: sticky, `button-color` для активной вкладки, 2px border-bottom
- `App.tsx` — `activeTab` state + `visibleVideos` через `useMemo`
- `VideoList.tsx` — prop `activeTab`, кастомный empty state для каждой вкладки

## Acceptance Criteria
- [x] Tab bar виден, прилипает ниже заголовка (z-index: 90)
- [x] «Видео»: только `is_watched === false`
- [x] «Просмотрено»: только `is_watched === true`
- [x] Отметка просмотрено → карточка мгновенно перемещается между вкладками
- [x] «Подписки»: пустое состояние с 🔔 и текстом
- [x] Активная вкладка: `button-color` + 2px border
- [x] Нет backend-изменений
- [x] `VideoCard.tsx`, `Player.tsx` не тронуты
- [x] TypeScript strict — no any

Closes #37