### PR TITLE
fix: remove header, TabBar is the only top bar (#42)

### DIFF
--- a/miniapp/src/App.tsx
+++ b/miniapp/src/App.tsx
@@ -105,11 +105,6 @@ function App() {
 
   return (
     <div className="app">
-      <header className="app-header">
-        <h1>Видео</h1>
-        {user && <span className="user-name">{user.firstName || user.username}</span>}
-      </header>
-
       <TabBar activeTab={activeTab} onChange={setActiveTab} />
 
       <main className="app-content">

--- a/miniapp/src/components/TabBar.css
+++ b/miniapp/src/components/TabBar.css
@@ -1,6 +1,6 @@
 .tab-bar {
   position: sticky;
-  top: 57px;
+  top: 0;
   z-index: 90;
   display: flex;
   background: var(--tg-theme-bg-color);


### PR DESCRIPTION
Убираем отдельный header (Видео + имя пользователя) — TabBar теперь единственная шапка приложения.

- Удалён `<header class="app-header">` из App.tsx
- TabBar прилипает к самому верху (`top: 0`)
- Освобождает ~53px вертикального пространства

Closes #42