### PR TITLE
[auto] fix: alt limit 2 + strict thresholds + require both signals (#50)

### DIFF
--- a/backend/src/api/routes/videos.ts
+++ b/backend/src/api/routes/videos.ts
@@ -260,9 +260,10 @@ function durationSimilarity(
 
 // ─── AltSearch ─────────────────────────────────────────────────────────────
 
-const CHANNEL_SIM_THRESHOLD = 0.45;
-const TITLE_OVERLAP_THRESHOLD = 0.4;
+const CHANNEL_SIM_THRESHOLD = 0.5;
+const TITLE_OVERLAP_THRESHOLD = 0.65;
 const DURATION_DIFF_HARD_LIMIT = 0.05;
+const MAX_ALTERNATIVES = 2;
 
 async function findAlternatives(
   query: string,
@@ -291,11 +292,13 @@ async function findAlternatives(
 
     scored.sort((a, b) => b.score - a.score);
 
+    let addedCount = 0;
     for (const { alt, chSim, titleOvr, durSim } of scored) {
+      if (addedCount >= MAX_ALTERNATIVES) break;
       const isChannelOk = chSim >= CHANNEL_SIM_THRESHOLD;
       const isTitleOk = titleOvr >= TITLE_OVERLAP_THRESHOLD;
 
-      if (!isChannelOk && !isTitleOk) {
+      if (!isChannelOk || !isTitleOk) {
         apiLogger.debug(
           { title: alt.title, chSim: chSim.toFixed(2), titleOvr: titleOvr.toFixed(2), durSim: durSim.toFixed(2) },
           'Skipping alt: below thresholds'
@@ -333,6 +336,7 @@ async function findAlternatives(
         duration: alt.duration,
         parentId
       });
+      addedCount++;
       apiLogger.info(
         {
           title: alt.title,


### PR DESCRIPTION
## Проблема
При null originalDuration (YouTube часто не отдаёт длину через Invidious) дурейшн-фильтр не работает. Добавлялось 5-6 альтернатив со слабым совпадением (chSim 0.06, titleOvr 0.55).

## Изменения

| Константа | До | После |
|---|---|---|
| TITLE_OVERLAP_THRESHOLD | 0.4 | **0.65** |
| CHANNEL_SIM_THRESHOLD | 0.45 | **0.5** |
| MAX_ALTERNATIVES | — | **2** |
| Gate logic | either channel OR title | **both channel AND title** |

## Поведение
- Добавляется максимум 2 альтернативы (топ-2 по score)
- Видео должно пройти **оба** порога — и по каналу, и по заголовку
- Слабые совпадения типа chSim=0.06 теперь полностью отклоняются

## Verification
- ✅ TypeScript compiles

Closes #50