### PR TITLE
[auto] fix: title-only gate, TITLE_OVERLAP_THRESHOLD 0.65→0.55 (#52)

### DIFF
--- a/backend/src/api/routes/videos.ts
+++ b/backend/src/api/routes/videos.ts
@@ -261,7 +261,7 @@ function durationSimilarity(
 // ─── AltSearch ─────────────────────────────────────────────────────────────
 
 const CHANNEL_SIM_THRESHOLD = 0.5;
-const TITLE_OVERLAP_THRESHOLD = 0.65;
+const TITLE_OVERLAP_THRESHOLD = 0.55;
 const DURATION_DIFF_HARD_LIMIT = 0.05;
 const MAX_ALTERNATIVES = 2;
 
@@ -298,10 +298,10 @@ async function findAlternatives(
       const isChannelOk = chSim >= CHANNEL_SIM_THRESHOLD;
       const isTitleOk = titleOvr >= TITLE_OVERLAP_THRESHOLD;
 
-      if (!isChannelOk || !isTitleOk) {
+      if (!isTitleOk) {
         apiLogger.debug(
           { title: alt.title, chSim: chSim.toFixed(2), titleOvr: titleOvr.toFixed(2), durSim: durSim.toFixed(2) },
-          'Skipping alt: below thresholds'
+          'Skipping alt: title below threshold'
         );
         continue;
       }


### PR DESCRIPTION
## Проблема
После PR #51 альтернативы перестали находиться совсем — требование **обоих** сигналов (channel AND title) слишком жёсткое.

## Причина
Channel similarity на VK/Rutube почти всегда низкий: видео загружают случайные паблики, а не официальный канал автора. Поэтому `isChannelOk` почти никогда не выполняется.

## Решение
- **Gate**: только `!isTitleOk` (title — главный сигнал, обязателен)
- Channel sim остаётся как весовой коэффициент в score (0.25), но не как жёсткий фильтр
- TITLE_OVERLAP_THRESHOLD: 0.65 → **0.55**
- MAX_ALTERNATIVES = 2 остаётся

## Итоговые правила
1. Title overlap < 0.55 → пропускаем
2. Duration diff > 5% (если обе известны) → пропускаем  
3. Берём топ-2 по score

## Verification
- ✅ TypeScript compiles

Closes #52