### PR TITLE
[auto] fix: show alternatives for watched videos (#63)

### DIFF
--- a/miniapp/src/App.tsx
+++ b/miniapp/src/App.tsx
@@ -123,6 +123,7 @@ function App() {
       <main className="app-content">
         <VideoList
           videos={visibleVideos}
+          allVideos={videos}
           loading={loading}
           onVideoClick={handleVideoClick}
           onDelete={handleDelete}

--- a/miniapp/src/components/VideoList.tsx
+++ b/miniapp/src/components/VideoList.tsx
@@ -5,6 +5,7 @@ import './VideoList.css';
 
 interface VideoListProps {
   videos: Video[];
+  allVideos?: Video[];
   onVideoClick?: (video: Video) => void;
   onDelete?: (id: number) => void;
   onMarkWatched?: (id: number, isWatched: boolean) => void;
@@ -37,6 +38,7 @@ const EMPTY_STATE: Record<Tab, { icon: string; title: string; message: string }>
 
 export function VideoList({
   videos,
+  allVideos,
   onVideoClick,
   onDelete,
   onMarkWatched,
@@ -67,11 +69,12 @@ export function VideoList({
   }
 
   const rootVideos = videos.filter((v) => !v.parent_id);
+  const altSource = allVideos ?? videos;
 
   return (
     <div className="video-list">
       {rootVideos.map((video) => {
-        const alternatives = videos.filter((alt) => alt.parent_id === video.id);
+        const alternatives = altSource.filter((alt) => alt.parent_id === video.id);
         return (
           <VideoCard
             key={video.id}


### PR DESCRIPTION
## Summary

Alternatives were not shown when a parent video was marked as watched.

**Root cause:** `visibleVideos` in App.tsx filtered out all `is_watched` videos before passing to VideoList. Alternatives were then searched inside this already-filtered array — so watched alternatives simply disappeared.

**Fix:**
- Pass full `videos` state to VideoList as `allVideos` prop
- Use `allVideos` for alternatives lookup instead of the filtered array
- Root video iteration still uses the filtered `videos` prop (per-tab visibility)

Closes #63