### PR TITLE
[auto] fix: migrate deploy.sh and project-context from Swarm to Docker Compose (#82)

### DIFF
--- a/.cursor/rules/debug-workflow.mdc
+++ b/.cursor/rules/debug-workflow.mdc
@@ -8,23 +8,23 @@ alwaysApply: true
 ## Триггер
 Любое сочетание: маркер деплоя + маркер проблемы.
 
-**Маркеры деплоя:** деплой, deploy, выкат, после выката, swarm, stack deploy, docker.
+**Маркеры деплоя:** деплой, deploy, выкат, после выката, compose, docker.
 **Маркеры проблемы:** баг, ошибка, не работает, сломалось, bug, broken, fails, crash.
 
 ## Алгоритм
 1. Запусти `@debug-fixer` немедленно в том же чате.
 2. Уточни (не блокируй если нет): ожидаемое vs фактическое, шаги воспроизведения, что задеплоили.
-3. Итерации: локализация → фикс или диагностическое логирование → деплой в Swarm → проверка.
+3. Итерации: локализация → фикс или диагностическое логирование → деплой через Docker Compose → проверка.
 
 ## Особенности aitovideo
 - **UI (Mini App) в Telegram** — нельзя автопроверить агентом, нужен человек.
 - **Backend API** — агент проверяет через `curl` к `/health` и эндпоинтам.
 - **Bot** — проверить через отправку тестовой ссылки боту.
-- Логи смотреть через: `docker service logs aitovideo_backend --tail 100`
+- Логи смотреть через: `ssh root@83.217.220.3 'cd /opt/aitovideo && docker compose logs --tail 100'`
 
 ## Деплой после фикса
 ```bash
-docker stack deploy -c docker-compose.swarm.yml aitovideo
+ssh root@83.217.220.3 'cd /opt/aitovideo && docker compose pull && docker compose up -d'
 ```
 
 ## Формат результата

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -13,7 +13,7 @@ Telegram Mini App для очереди видео (YouTube, Rutube, VK Video).
 - **Frontend:** React + TypeScript + Vite
 - **Bot:** node-telegram-bot-api
 - **Логирование:** pino + pino-pretty (dev)
-- **Деплой:** Docker Swarm (основной), Docker Compose (legacy)
+- **Деплой:** Docker Compose (VPS)
 
 ## Структура
 ```
@@ -33,17 +33,12 @@ aitovideo/
 ```
 
 ## Деплой
-**Production — Docker Swarm:**
+**Production — Docker Compose (VPS):**
 ```bash
-docker stack deploy -c docker-compose.swarm.yml aitovideo
+cd /opt/aitovideo && docker compose up -d
 ```
 
-**Legacy — Docker Compose:**
-```bash
-docker-compose up -d
-```
-
-**НЕ запускать локально для проверки после деплоя** — только через Swarm.
+**НЕ запускать локально для проверки после деплоя** — только через VPS.
 
 ## База данных
 - SQLite, путь: `backend/data/videos.db`
@@ -79,6 +74,6 @@ apiLogger.error({ err, userId }, 'Something failed');
 
 ## Human review обязателен при
 - Изменении схемы БД (удаление/переименование)
-- Изменении деплой-конфигурации (Swarm stack)
+- Изменении деплой-конфигурации (Compose / VPS)
 - Новых внешних API интеграциях
 - Major обновлениях зависимостей

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,14 @@ Backend serves API + bot; Mini App is the UI inside Telegram.
 - **Frontend:** React + TypeScript + Vite
 - **Bot:** node-telegram-bot-api
 - **Logging:** pino (structured JSON); use child loggers, NOT console.log
-- **Deploy:** Docker Swarm via Portainer; images pushed to `rast53/*` on Docker Hub
+- **Deploy:** Docker Compose on VPS; images pushed to `rast53/*` on Docker Hub
 
 ## Commands
 | Script | Purpose |
 |---|---|
 | `./scripts/check.sh` | TypeScript type-check (backend + miniapp) |
 | `./scripts/build.sh` | Build Docker images |
-| `./scripts/deploy.sh` | Deploy stack to Swarm |
+| `./scripts/deploy.sh` | Build, push & deploy via Docker Compose on VPS |
 | `./scripts/logs.sh` | Tail service logs |
 | `./scripts/health.sh` | Health-check endpoints |
 | `./scripts/watch-agent.sh` | Monitor agent progress (progress.md → Telegram) |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCKER_USER="${DOCKER_USER:-rast53}"
-STACK_NAME="${STACK_NAME:-aitovideo}"
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
-EXECUTE_SWARM="${EXECUTE_SWARM:-0}"
+VPS_HOST="${VPS_HOST:-root@83.217.220.3}"
+VPS_DIR="${VPS_DIR:-/opt/aitovideo}"
+HEALTH_URL="${HEALTH_URL:-https://video.ragpt.ru/api/health}"
 DRY_RUN=0
 VERSION="latest"
 
@@ -18,13 +19,13 @@ Examples:
   ./scripts/deploy.sh
   ./scripts/deploy.sh 1.2.3
   ./scripts/deploy.sh --dry-run
-  EXECUTE_SWARM=1 ./scripts/deploy.sh latest
 
 Environment variables:
   DOCKER_USER    Docker Hub namespace (default: rast53)
-  STACK_NAME     Docker Swarm stack name (default: aitovideo)
-  COMPOSE_FILE   Swarm compose file path from repo root (default: docker-compose.yml)
-  EXECUTE_SWARM  Set to 1 to run Swarm commands on a VPS manager node
+  COMPOSE_FILE   Compose file path from repo root (default: docker-compose.yml)
+  VPS_HOST       SSH target host (default: root@83.217.220.3)
+  VPS_DIR        Project directory on VPS (default: /opt/aitovideo)
+  HEALTH_URL     Health-check URL (default: https://video.ragpt.ru/api/health)
 EOF
 }
 
@@ -38,7 +39,8 @@ require_cmd() {
     echo "ERROR: required command '$cmd' is not installed."
     case "$cmd" in
       docker) hint "Install Docker CLI/Engine and retry." ;;
-      timeout) hint "Install coreutils (timeout command) or run Swarm logs manually." ;;
+      ssh)    hint "Install OpenSSH client and retry." ;;
+      curl)   hint "Install curl and retry." ;;
     esac
     exit 1
   fi
@@ -78,18 +80,16 @@ done
 BACKEND_IMAGE="${DOCKER_USER}/aitovideo-backend"
 MINIAPP_IMAGE="${DOCKER_USER}/aitovideo-miniapp"
 
+# --- Pre-flight checks ---
 echo "[deploy] Pre-flight checks..."
 if [[ $DRY_RUN -eq 0 ]]; then
   require_cmd docker
-  require_cmd timeout
+  require_cmd ssh
+  require_cmd curl
 else
   if ! command -v docker >/dev/null 2>&1; then
     echo "WARNING: docker command is not available; running in structure-only dry-run mode."
     hint "Install Docker to execute real build/push operations."
-  fi
-  if ! command -v timeout >/dev/null 2>&1; then
-    echo "WARNING: timeout command is not available; log tail timeout won't be executable outside dry-run."
-    hint "Install coreutils to enable bounded log tailing."
   fi
 fi
 
@@ -113,6 +113,7 @@ if [[ $DRY_RUN -eq 0 ]]; then
   fi
 fi
 
+# --- Build ---
 echo "[deploy] Building Docker images (version: $VERSION)..."
 run_or_print "cd \"$ROOT_DIR\" && docker build -t \"${BACKEND_IMAGE}:${VERSION}\" ./backend"
 run_or_print "cd \"$ROOT_DIR\" && docker build -t \"${MINIAPP_IMAGE}:${VERSION}\" ./miniapp"
@@ -122,6 +123,7 @@ if [[ "$VERSION" != "latest" ]]; then
   run_or_print "docker tag \"${MINIAPP_IMAGE}:${VERSION}\" \"${MINIAPP_IMAGE}:latest\""
 fi
 
+# --- Push ---
 echo "[deploy] Pushing Docker images to registry..."
 echo "Target registry namespace: ${DOCKER_USER}"
 if [[ $DRY_RUN -eq 0 ]]; then
@@ -135,28 +137,34 @@ if [[ "$VERSION" != "latest" ]]; then
   run_or_print "docker push \"${MINIAPP_IMAGE}:latest\""
 fi
 
-echo "[deploy] Swarm update/restart step (requires VPS access)."
-if [[ "$EXECUTE_SWARM" == "1" ]]; then
-  echo "EXECUTE_SWARM=1 detected, applying stack update and forcing service restart..."
-  run_or_print "cd \"$ROOT_DIR\" && docker stack deploy -c \"$COMPOSE_FILE\" \"$STACK_NAME\""
-  run_or_print "docker service update --force \"${STACK_NAME}_backend\""
-  run_or_print "docker service update --force \"${STACK_NAME}_bot\""
-  run_or_print "docker service update --force \"${STACK_NAME}_miniapp\""
+# --- Deploy via SSH + Docker Compose ---
+echo "[deploy] Deploying on VPS ($VPS_HOST)..."
+run_or_print "ssh $VPS_HOST 'cd $VPS_DIR && docker compose pull && docker compose up -d'"
 
-  echo "[deploy] Tailing service logs for 30s each..."
-  run_or_print "timeout 30s docker service logs \"${STACK_NAME}_backend\" --tail 100 -f"
-  run_or_print "timeout 30s docker service logs \"${STACK_NAME}_bot\" --tail 100 -f"
-  run_or_print "timeout 30s docker service logs \"${STACK_NAME}_miniapp\" --tail 100 -f"
+# --- Health check ---
+echo "[deploy] Running health check ($HEALTH_URL)..."
+if [[ $DRY_RUN -eq 0 ]]; then
+  sleep 5
+  set +e
+  status="$(curl -sS -m 15 -o /dev/null -w "%{http_code}" "$HEALTH_URL")"
+  curl_rc=$?
+  set -e
+
+  if [[ $curl_rc -ne 0 ]]; then
+    echo "WARNING: could not reach health endpoint ($HEALTH_URL)."
+    hint "Check VPS connectivity and backend logs."
+  elif [[ "$status" == "200" ]]; then
+    echo "[deploy] Health check passed (HTTP $status)."
+  else
+    echo "WARNING: health check returned HTTP $status."
+    hint "Inspect logs: ssh $VPS_HOST 'cd $VPS_DIR && docker compose logs --tail 50'"
+  fi
 else
-  echo "requires VPS access: run these commands on the Swarm manager:"
-  echo "  docker stack deploy -c \"$COMPOSE_FILE\" \"$STACK_NAME\""
-  echo "  docker service update --force \"${STACK_NAME}_backend\""
-  echo "  docker service update --force \"${STACK_NAME}_bot\""
-  echo "  docker service update --force \"${STACK_NAME}_miniapp\""
-  echo "  timeout 30s docker service logs \"${STACK_NAME}_backend\" --tail 100 -f"
-  echo "  timeout 30s docker service logs \"${STACK_NAME}_bot\" --tail 100 -f"
-  echo "  timeout 30s docker service logs \"${STACK_NAME}_miniapp\" --tail 100 -f"
-  hint "Use EXECUTE_SWARM=1 only when running on VPS manager with Swarm access."
+  echo "[dry-run] curl -sS -m 15 $HEALTH_URL"
 fi
+
+# --- Tail logs ---
+echo "[deploy] Tailing logs..."
+run_or_print "ssh $VPS_HOST 'cd $VPS_DIR && docker compose logs --tail 30'"
 
 echo "[deploy] Done."


### PR DESCRIPTION
## Summary
- Replaced Swarm-based deploy logic in `deploy.sh` with SSH + Docker Compose flow
- Deploy now: SSH to root@83.217.220.3, docker compose pull && docker compose up -d
- Added post-deploy health check (curl https://video.ragpt.ru/api/health) and log tailing via docker compose
- Updated project-context.mdc, debug-workflow.mdc, AGENTS.md to reference Docker Compose

Closes #82